### PR TITLE
feat(users): Implement user management endpoints

### DIFF
--- a/src/common/dto/pagination.dto.ts
+++ b/src/common/dto/pagination.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from "class-transformer";
+import { IsOptional, IsPositive, Min } from "class-validator";
+
+
+export class PaginationDto {
+
+    @IsOptional()
+    @IsPositive()
+    @Type(() => Number) // enableImplicitConversions: true
+    limit?: number;
+
+    @IsOptional()
+    @Min(0)
+    @Type(() => Number) // enableImplicitConversions: true
+    offset?: number;
+
+}

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,4 +1,6 @@
-import { PartialType } from '@nestjs/swagger';
+import { PartialType, OmitType } from '@nestjs/swagger';
 import { CreateUserDto } from './create-user.dto';
 
-export class UpdateUserDto extends PartialType(CreateUserDto) {}
+class UpdateUserPayload extends OmitType(CreateUserDto, ['password'] as const) {}
+
+export class UpdateUserDto extends PartialType(UpdateUserPayload) {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, ParseUUIDPipe } from '@nestjs/common';
 import { UsersService } from './users.service';
-import { UpdateUserDto } from './dto/update-user.dto';
 import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
 
 @Controller({
   path: 'users',
@@ -10,29 +11,31 @@ import { CreateUserDto } from './dto/create-user.dto';
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
-
   @Post()
   create(@Body() createUserDto: CreateUserDto) {
     return this.usersService.create(createUserDto);
   }
 
   @Get()
-  findAll() {
-    return this.usersService.findAll();
+  findAll(@Query() paginationDto: PaginationDto) {
+    return this.usersService.findAll(paginationDto);
   }
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.usersService.findOne(+id);
+  @Get(':uuid')
+  findOne(@Param('uuid', new ParseUUIDPipe()) uuid: string) {
+    return this.usersService.findOne(uuid);
   }
 
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
-    return this.usersService.update(+id, updateUserDto);
+  @Patch(':uuid')
+  update(
+    @Param('uuid', new ParseUUIDPipe()) uuid: string,
+    @Body() updateUserDto: UpdateUserDto
+  ) {
+    return this.usersService.update(uuid, updateUserDto);
   }
 
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.usersService.remove(+id);
+  @Delete(':uuid')
+  remove(@Param('uuid', new ParseUUIDPipe()) uuid: string) {
+    return this.usersService.remove(uuid);
   }
 }


### PR DESCRIPTION
This commit introduces a complete set of RESTful API endpoints for user management, replacing the existing placeholder logic.

The following functionalities have been implemented:
- **Create User:** A `POST /users` endpoint to create a new user. Passwords are automatically hashed using bcrypt.
- **Get User List (Paginated):** A `GET /users` endpoint that returns a paginated list of users. It accepts `limit` and `offset` query parameters for pagination control.
- **Get User by UUID:** A `GET /users/{uuid}` endpoint to retrieve the details of a single user by their UUID.
- **Update User:** A `PATCH /users/{uuid}` endpoint to update a user's information. The password cannot be updated through this endpoint.
- **Delete User:** A `DELETE /users/{uuid}` endpoint that performs a soft delete on the user.

All endpoints now use UUIDs for resource identification instead of numeric IDs to align with best practices. The password field is consistently excluded from all API responses to enhance security.

A reusable `PaginationDto` has been created in a new `src/common/dto` directory to ensure consistent pagination handling across the application.