### PR TITLE
feat: Implementar listado de roles y plataformas activas

### DIFF
--- a/src/platforms/platforms.service.ts
+++ b/src/platforms/platforms.service.ts
@@ -1,15 +1,23 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreatePlatformDto } from './dto/create-platform.dto';
 import { UpdatePlatformDto } from './dto/update-platform.dto';
+import { Platform } from './entities/platform.entity';
 
 @Injectable()
 export class PlatformsService {
+  constructor(
+    @InjectRepository(Platform)
+    private readonly platformRepository: Repository<Platform>,
+  ) {}
+
   create(createPlatformDto: CreatePlatformDto) {
     return 'This action adds a new platform';
   }
 
-  findAll() {
-    return `This action returns all platforms`;
+  async findAll() {
+    return this.platformRepository.find({ where: { is_active: true } });
   }
 
   findOne(id: number) {

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -1,15 +1,23 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreateRoleDto } from './dto/create-role.dto';
 import { UpdateRoleDto } from './dto/update-role.dto';
+import { Role } from './entities/role.entity';
 
 @Injectable()
 export class RolesService {
+  constructor(
+    @InjectRepository(Role)
+    private readonly roleRepository: Repository<Role>,
+  ) {}
+
   create(createRoleDto: CreateRoleDto) {
     return 'This action adds a new role';
   }
 
-  findAll() {
-    return `This action returns all roles`;
+  async findAll() {
+    return this.roleRepository.find({ where: { is_active: true } });
   }
 
   findOne(id: number) {


### PR DESCRIPTION
Se agregan los endpoints GET /roles y GET /platforms para obtener un listado de todos los roles y plataformas que se encuentren activos.

- Se modifica el método `findAll` en `RolesService` para filtrar los roles donde `is_active` sea `true`.
- Se modifica el método `findAll` en `PlatformsService` para filtrar las plataformas donde `is_active` sea `true`.
- Se confirma que los controladores `RolesController` y `PlatformsController` exponen correctamente estos servicios.