### PR TITLE
feat: Create Clients and Addresses modules

### DIFF
--- a/src/addresses/addresses.controller.ts
+++ b/src/addresses/addresses.controller.ts
@@ -1,0 +1,39 @@
+import {
+  Controller,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  ParseUUIDPipe
+} from '@nestjs/common';
+import {
+  AddressesService
+} from './addresses.service';
+import {
+  UpdateAddressDto
+} from './dto/update-address.dto';
+import {
+  ApiTags
+} from '@nestjs/swagger';
+
+@ApiTags('Addresses')
+@Controller({
+  path: 'addresses',
+  version: '1',
+})
+export class AddressesController {
+  constructor(private readonly addressesService: AddressesService) {}
+
+  @Patch(':uuid')
+  update(
+    @Param('uuid', new ParseUUIDPipe()) uuid: string,
+    @Body() updateAddressDto: UpdateAddressDto,
+  ) {
+    return this.addressesService.update(uuid, updateAddressDto);
+  }
+
+  @Delete(':uuid')
+  remove(@Param('uuid', new ParseUUIDPipe()) uuid: string) {
+    return this.addressesService.remove(uuid);
+  }
+}

--- a/src/addresses/addresses.module.ts
+++ b/src/addresses/addresses.module.ts
@@ -1,0 +1,30 @@
+import {
+  Module,
+  forwardRef
+} from '@nestjs/common';
+import {
+  AddressesService
+} from './addresses.service';
+import {
+  AddressesController
+} from './addresses.controller';
+import {
+  TypeOrmModule
+} from '@nestjs/typeorm';
+import {
+  Address
+} from './entities/address.entity';
+import {
+  ClientsModule
+} from 'src/clients/clients.module';
+
+@Module({
+  controllers: [AddressesController],
+  providers: [AddressesService],
+  imports: [
+    TypeOrmModule.forFeature([Address]),
+    forwardRef(() => ClientsModule),
+  ],
+  exports: [AddressesService],
+})
+export class AddressesModule {}

--- a/src/addresses/addresses.service.ts
+++ b/src/addresses/addresses.service.ts
@@ -1,0 +1,151 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  InjectRepository
+} from '@nestjs/typeorm';
+import {
+  Repository,
+  QueryFailedError,
+  Not
+} from 'typeorm';
+import {
+  Address
+} from './entities/address.entity';
+import {
+  CreateAddressDto
+} from './dto/create-address.dto';
+import {
+  UpdateAddressDto
+} from './dto/update-address.dto';
+import {
+  ClientsService
+} from 'src/clients/clients.service';
+
+@Injectable()
+export class AddressesService {
+
+  constructor(
+    @InjectRepository(Address)
+    private readonly addressRepository: Repository < Address > ,
+    private readonly clientsService: ClientsService,
+  ) {}
+
+  async addAddressToClient(clientUuid: string, createAddressDto: CreateAddressDto) {
+    const client = await this.clientsService.getClientByUuid(clientUuid);
+
+    if (createAddressDto.is_primary) {
+      await this.unsetCurrentPrimaryAddress(client.id);
+    }
+
+    const newAddress = this.addressRepository.create({
+      ...createAddressDto,
+      client: client,
+    });
+
+    try {
+      const savedAddress = await this.addressRepository.save(newAddress);
+      return {
+        success: true,
+        message: 'Address added successfully!',
+        data: savedAddress,
+      };
+    } catch (error) {
+      this.handleDBErrors(error);
+    }
+  }
+
+  async update(uuid: string, updateAddressDto: UpdateAddressDto) {
+    const address = await this.getAddressByUuid(uuid);
+
+    if (updateAddressDto.is_primary) {
+      await this.unsetCurrentPrimaryAddress(address.client.id, address.id);
+    }
+
+    this.addressRepository.merge(address, updateAddressDto);
+    try {
+      const updatedAddress = await this.addressRepository.save(address);
+      return {
+        success: true,
+        message: 'Address updated successfully!',
+        data: updatedAddress,
+      };
+    } catch (error) {
+      this.handleDBErrors(error);
+    }
+  }
+
+  async remove(uuid: string) {
+    const address = await this.getAddressByUuid(uuid);
+    await this.addressRepository.softDelete({
+      uuid
+    });
+    return {
+      success: true,
+      message: 'Address deleted successfully!',
+      data: address,
+    };
+  }
+
+  async findOne(uuid: string) {
+    const address = await this.getAddressByUuid(uuid);
+    return {
+      success: true,
+      message: 'Address found!',
+      data: address,
+    };
+  }
+
+  private async getAddressByUuid(uuid: string): Promise < Address > {
+    const address = await this.addressRepository.findOne({
+      where: {
+        uuid
+      },
+      relations: ['client'],
+    });
+    if (!address) {
+      throw new NotFoundException(`Address with uuid ${uuid} not found!`);
+    }
+    return address;
+  }
+
+  private async unsetCurrentPrimaryAddress(clientId: number, newPrimaryAddressId ? : number) {
+    const whereClause: any = {
+      client: {
+        id: clientId
+      },
+      is_primary: true,
+    };
+
+    if (newPrimaryAddressId) {
+      whereClause.id = Not(newPrimaryAddressId);
+    }
+
+    const currentPrimary = await this.addressRepository.findOne({
+      where: whereClause
+    });
+
+    if (currentPrimary) {
+      currentPrimary.is_primary = false;
+      await this.addressRepository.save(currentPrimary);
+    }
+  }
+
+  private handleDBErrors(error: any): never {
+    if (error instanceof NotFoundException || error instanceof BadRequestException) {
+      throw error;
+    }
+
+    if (error instanceof QueryFailedError) {
+      if ((error as any).errno === 1062) {
+        throw new BadRequestException((error as any).detail || (error as any).sqlMessage || 'Duplicate entry');
+      }
+    }
+
+    console.error(error);
+    throw new InternalServerErrorException('Server Error. Please contact the system administrator!');
+  }
+}

--- a/src/addresses/dto/create-address.dto.ts
+++ b/src/addresses/dto/create-address.dto.ts
@@ -1,0 +1,66 @@
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsNumber,
+  IsNotEmpty,
+  MaxLength,
+  IsLatitude,
+  IsLongitude,
+} from 'class-validator';
+
+export class CreateAddressDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  street: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  external_number ? : string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(50)
+  internal_number ? : string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  neighborhood: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  municipality: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  state: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  country: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(10)
+  postal_code: string;
+
+  @IsNumber()
+  @IsOptional()
+  @IsLatitude()
+  latitude ? : number;
+
+  @IsNumber()
+  @IsOptional()
+  @IsLongitude()
+  longitude ? : number;
+
+  @IsBoolean()
+  @IsOptional()
+  is_primary ? : boolean;
+}

--- a/src/addresses/dto/update-address.dto.ts
+++ b/src/addresses/dto/update-address.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateAddressDto } from './create-address.dto';
+
+export class UpdateAddressDto extends PartialType(CreateAddressDto) {}

--- a/src/addresses/entities/address.entity.ts
+++ b/src/addresses/entities/address.entity.ts
@@ -1,0 +1,141 @@
+import {
+  Client
+} from "src/clients/entities/client.entity";
+import {
+  BeforeInsert,
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  JoinColumn
+} from "typeorm";
+import {
+  v4 as uuidv4
+} from 'uuid';
+
+@Entity('addresses')
+export class Address {
+
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({
+    type: 'uuid',
+    unique: true
+  })
+  uuid: string;
+
+  @Column({
+    type: 'varchar',
+    length: 255
+  })
+  street: string;
+
+  @Column({
+    type: 'varchar',
+    length: 50,
+    name: 'external_number',
+    nullable: true
+  })
+  external_number: string;
+
+  @Column({
+    type: 'varchar',
+    length: 50,
+    name: 'internal_number',
+    nullable: true
+  })
+  internal_number: string;
+
+  @Column({
+    type: 'varchar',
+    length: 255
+  })
+  neighborhood: string;
+
+  @Column({
+    type: 'varchar',
+    length: 255
+  })
+  municipality: string;
+
+  @Column({
+    type: 'varchar',
+    length: 255
+  })
+  state: string;
+
+  @Column({
+    type: 'varchar',
+    length: 255
+  })
+  country: string;
+
+  @Column({
+    type: 'varchar',
+    length: 10,
+    name: 'postal_code'
+  })
+  postal_code: string;
+
+  @Column({
+    type: 'decimal',
+    precision: 11,
+    scale: 8,
+    nullable: true
+  })
+  longitude: number;
+
+  @Column({
+    type: 'decimal',
+    precision: 10,
+    scale: 8,
+    nullable: true
+  })
+  latitude: number;
+
+  @Column('bool', {
+    default: false,
+    name: 'is_primary'
+  })
+  is_primary: boolean;
+
+  @Column('bool', {
+    default: true
+  })
+  is_active: boolean;
+
+  @CreateDateColumn({
+    type: 'timestamp',
+    name: 'created_at'
+  })
+  created_at: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp',
+    name: 'updated_at'
+  })
+  updated_at: Date;
+
+  @DeleteDateColumn({
+    name: 'deleted_at',
+    nullable: true
+  })
+  deleted_at ? : Date | null;
+
+  @ManyToOne(() => Client, (client) => client.addresses, {
+    onDelete: 'CASCADE'
+  })
+  @JoinColumn({
+    name: 'client_id'
+  })
+  client: Client;
+
+  @BeforeInsert()
+  generateUuid() {
+    this.uuid = uuidv4();
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,13 +1,39 @@
-import { Module } from '@nestjs/common';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
-import { ConfigModule } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { ProductsModule } from './products/products.module';
-import { AuthModule } from './auth/auth.module';
-import { PlatformsModule } from './platforms/platforms.module';
-import { RolesModule } from './roles/roles.module';
-import { UsersModule } from './users/users.module';
+import {
+  Module
+} from '@nestjs/common';
+import {
+  AppController
+} from './app.controller';
+import {
+  AppService
+} from './app.service';
+import {
+  ConfigModule
+} from '@nestjs/config';
+import {
+  TypeOrmModule
+} from '@nestjs/typeorm';
+import {
+  ProductsModule
+} from './products/products.module';
+import {
+  AuthModule
+} from './auth/auth.module';
+import {
+  PlatformsModule
+} from './platforms/platforms.module';
+import {
+  RolesModule
+} from './roles/roles.module';
+import {
+  UsersModule
+} from './users/users.module';
+import {
+  ClientsModule
+} from './clients/clients.module';
+import {
+  AddressesModule
+} from './addresses/addresses.module';
 
 
 @Module({
@@ -25,15 +51,15 @@ import { UsersModule } from './users/users.module';
       username: process.env.DB_USERNAME,
       password: process.env.DB_PASSWORD,
       autoLoadEntities: process.env.DB_AUTOLOAD === 'true', //Carga en automático Entidades.
-      synchronize: process.env.DB_SYNCHRONIZE === 'true',   //Sincroniza automáticamente el esquema de la base de datos cada vez que se levanta el servidor. NO RECOMENDADO EN PRODUCCIÓN 
-      logging: process.env.DB_LOGGING === 'true',           //Muestra en consola las consultas que ejecuta TypeORM. NO RECOMENDADO EN PRODUCCIÓN 
+      synchronize: process.env.DB_SYNCHRONIZE === 'true', //Sincroniza automáticamente el esquema de la base de datos cada vez que se levanta el servidor. NO RECOMENDADO EN PRODUCCIÓN
+      logging: process.env.DB_LOGGING === 'true', //Muestra en consola las consultas que ejecuta TypeORM. NO RECOMENDADO EN PRODUCCIÓN
     }),
 
-    ProductsModule, AuthModule, PlatformsModule, RolesModule, UsersModule
+    ProductsModule, AuthModule, PlatformsModule, RolesModule, UsersModule, ClientsModule, AddressesModule
   ],
   controllers: [AppController],
   providers: [AppService],
-  
+
 })
 
-export class AppModule { }
+export class AppModule {}

--- a/src/clients/clients.controller.ts
+++ b/src/clients/clients.controller.ts
@@ -1,0 +1,81 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Query,
+  ParseUUIDPipe,
+  Put
+} from '@nestjs/common';
+import {
+  ClientsService
+} from './clients.service';
+import {
+  CreateClientDto
+} from './dto/create-client.dto';
+import {
+  UpdateClientDto
+} from './dto/update-client.dto';
+import {
+  QueryClientDto
+} from './dto/query-client.dto';
+import {
+  AddressesService
+} from 'src/addresses/addresses.service';
+import {
+  CreateAddressDto
+} from 'src/addresses/dto/create-address.dto';
+import {
+  ApiTags
+} from '@nestjs/swagger';
+
+@ApiTags('Clients')
+@Controller({
+  path: 'clients',
+  version: '1',
+})
+export class ClientsController {
+  constructor(
+    private readonly clientsService: ClientsService,
+    private readonly addressesService: AddressesService,
+  ) {}
+
+  @Post()
+  create(@Body() createClientDto: CreateClientDto) {
+    return this.clientsService.create(createClientDto);
+  }
+
+  @Get()
+  findAll(@Query() queryClientDto: QueryClientDto) {
+    return this.clientsService.findAll(queryClientDto);
+  }
+
+  @Get(':uuid')
+  findOne(@Param('uuid', new ParseUUIDPipe()) uuid: string) {
+    return this.clientsService.findOne(uuid);
+  }
+
+  @Put(':uuid')
+  update(
+    @Param('uuid', new ParseUUIDPipe()) uuid: string,
+    @Body() updateClientDto: UpdateClientDto,
+  ) {
+    return this.clientsService.update(uuid, updateClientDto);
+  }
+
+  @Delete(':uuid')
+  remove(@Param('uuid', new ParseUUIDPipe()) uuid: string) {
+    return this.clientsService.remove(uuid);
+  }
+
+  @Post(':uuid/addresses')
+  addAddress(
+    @Param('uuid', new ParseUUIDPipe()) uuid: string,
+    @Body() createAddressDto: CreateAddressDto,
+  ) {
+    return this.addressesService.addAddressToClient(uuid, createAddressDto);
+  }
+}

--- a/src/clients/clients.module.ts
+++ b/src/clients/clients.module.ts
@@ -1,0 +1,29 @@
+import {
+  Module
+} from '@nestjs/common';
+import {
+  ClientsService
+} from './clients.service';
+import {
+  ClientsController
+} from './clients.controller';
+import {
+  TypeOrmModule
+} from '@nestjs/typeorm';
+import {
+  Client
+} from './entities/client.entity';
+import {
+  AddressesModule
+} from 'src/addresses/addresses.module';
+
+@Module({
+  controllers: [ClientsController],
+  providers: [ClientsService],
+  imports: [
+    TypeOrmModule.forFeature([Client]),
+    AddressesModule,
+  ],
+  exports: [ClientsService],
+})
+export class ClientsModule {}

--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -1,0 +1,177 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  InjectRepository
+} from '@nestjs/typeorm';
+import {
+  Repository,
+  QueryFailedError,
+  FindManyOptions,
+  Between
+} from 'typeorm';
+import {
+  Client
+} from './entities/client.entity';
+import {
+  CreateClientDto
+} from './dto/create-client.dto';
+import {
+  UpdateClientDto
+} from './dto/update-client.dto';
+import {
+  QueryClientDto
+} from './dto/query-client.dto';
+import {
+  CreateAddressDto
+} from 'src/addresses/dto/create-address.dto';
+
+@Injectable()
+export class ClientsService {
+
+  constructor(
+    @InjectRepository(Client)
+    private readonly clientRepository: Repository < Client > ,
+  ) {}
+
+  async create(createClientDto: CreateClientDto) {
+    const {
+      addresses,
+      ...clientData
+    } = createClientDto;
+
+    if (!addresses || addresses.length === 0) {
+      throw new BadRequestException('At least one address is required.');
+    }
+
+    this.ensureSinglePrimaryAddress(addresses);
+
+    const client = this.clientRepository.create({
+      ...clientData,
+      addresses: addresses.map(addr => ({ ...addr,
+        is_primary: addr.is_primary || false
+      })),
+    });
+
+    try {
+      const savedClient = await this.clientRepository.save(client);
+      return {
+        success: true,
+        message: 'Client created successfully!',
+        data: savedClient,
+      };
+    } catch (error) {
+      this.handleDBErrors(error);
+    }
+  }
+
+  async findAll(queryClientDto: QueryClientDto) {
+    const {
+      limit = 10, page = 1, is_active, startDate, endDate
+    } = queryClientDto;
+    const offset = (page - 1) * limit;
+
+    const where: FindManyOptions < Client > ['where'] = {};
+
+    if (is_active !== undefined) {
+      where.is_active = is_active;
+    }
+
+    if (startDate && endDate) {
+      where.created_at = Between(new Date(startDate), new Date(endDate));
+    }
+
+    const [clients, total] = await this.clientRepository.findAndCount({
+      where,
+      take: limit,
+      skip: offset,
+    });
+
+    return {
+      success: true,
+      message: 'Clients retrieved successfully!',
+      data: clients,
+      pagination: {
+        pageNumber: page,
+        totalPages: Math.ceil(total / limit),
+        totalCount: total,
+        hasPreviousPage: page > 1,
+        hasNextPage: total > page * limit,
+      },
+    };
+  }
+
+  async findOne(uuid: string) {
+    const client = await this.getClientByUuid(uuid);
+    return {
+      success: true,
+      message: 'Client found!',
+      data: client,
+    };
+  }
+
+  async update(uuid: string, updateClientDto: UpdateClientDto) {
+    const client = await this.getClientByUuid(uuid);
+    this.clientRepository.merge(client, updateClientDto);
+    try {
+      const updatedClient = await this.clientRepository.save(client);
+      return {
+        success: true,
+        message: 'Client updated successfully!',
+        data: updatedClient,
+      };
+    } catch (error) {
+      this.handleDBErrors(error);
+    }
+  }
+
+  async remove(uuid: string) {
+    const client = await this.getClientByUuid(uuid);
+    await this.clientRepository.softRemove(client);
+    return {
+      success: true,
+      message: 'Client and related addresses deleted successfully!',
+      data: client,
+    };
+  }
+
+  async getClientByUuid(uuid: string): Promise < Client > {
+    const client = await this.clientRepository.findOne({
+      where: {
+        uuid
+      }
+    });
+    if (!client) {
+      throw new NotFoundException(`Client with uuid ${uuid} not found!`);
+    }
+    return client;
+  }
+
+  private ensureSinglePrimaryAddress(addresses: CreateAddressDto[]) {
+    const primaryAddresses = addresses.filter(addr => addr.is_primary).length;
+    if (primaryAddresses > 1) {
+      throw new BadRequestException('Only one primary address is allowed.');
+    }
+    if (primaryAddresses === 0 && addresses.length > 0) {
+      addresses[0].is_primary = true;
+    }
+  }
+
+  private handleDBErrors(error: any): never {
+    if (error instanceof NotFoundException || error instanceof BadRequestException) {
+      throw error;
+    }
+
+    if (error instanceof QueryFailedError) {
+      if ((error as any).errno === 1062) {
+        throw new BadRequestException((error as any).detail || (error as any).sqlMessage || 'Duplicate entry');
+      }
+    }
+
+    console.error(error);
+    throw new InternalServerErrorException('Server Error. Please contact the system administrator!');
+  }
+}

--- a/src/clients/dto/create-client.dto.ts
+++ b/src/clients/dto/create-client.dto.ts
@@ -1,0 +1,44 @@
+import {
+  IsString,
+  IsEmail,
+  IsOptional,
+  IsArray,
+  ValidateNested,
+  IsNotEmpty,
+  MaxLength,
+} from 'class-validator';
+import {
+  Type
+} from 'class-transformer';
+import {
+  CreateAddressDto
+} from 'src/addresses/dto/create-address.dto';
+
+export class CreateClientDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  code: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  name: string;
+
+  @IsEmail()
+  @IsNotEmpty()
+  @MaxLength(255)
+  email: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(25)
+  phone ? : string;
+
+  @IsArray()
+  @ValidateNested({
+    each: true
+  })
+  @Type(() => CreateAddressDto)
+  addresses: CreateAddressDto[];
+}

--- a/src/clients/dto/query-client.dto.ts
+++ b/src/clients/dto/query-client.dto.ts
@@ -1,0 +1,28 @@
+import {
+  IsOptional,
+  IsBoolean,
+  IsDateString
+} from 'class-validator';
+import {
+  PaginationDto
+} from 'src/common/dto/pagination.dto';
+import {
+  Transform
+} from 'class-transformer';
+
+export class QueryClientDto extends PaginationDto {
+  @IsOptional()
+  @IsBoolean()
+  @Transform(({
+    value
+  }) => value === 'true' || value === true)
+  is_active ? : boolean;
+
+  @IsOptional()
+  @IsDateString()
+  startDate ? : string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate ? : string;
+}

--- a/src/clients/dto/update-client.dto.ts
+++ b/src/clients/dto/update-client.dto.ts
@@ -1,0 +1,14 @@
+import {
+  PartialType
+} from '@nestjs/mapped-types';
+import {
+  CreateClientDto
+} from './create-client.dto';
+import {
+  IsArray
+} from 'class-validator';
+
+export class UpdateClientDto extends PartialType(CreateClientDto) {
+  @IsArray()
+  addresses: never;
+}

--- a/src/clients/entities/client.entity.ts
+++ b/src/clients/entities/client.entity.ts
@@ -1,0 +1,97 @@
+import {
+  Address
+} from "src/addresses/entities/address.entity";
+import {
+  BeforeInsert,
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from "typeorm";
+import {
+  v4 as uuidv4
+} from 'uuid';
+
+@Entity('clients')
+export class Client {
+
+  @PrimaryGeneratedColumn('increment')
+  id: number;
+
+  @Column({
+    type: 'uuid',
+    unique: true
+  })
+  uuid: string;
+
+  @Column({
+    type: 'varchar',
+    length: 50,
+    unique: true
+  })
+  code: string;
+
+  @Column({
+    type: 'varchar',
+    length: 255
+  })
+  name: string;
+
+  @Column({
+    type: 'varchar',
+    length: 255,
+    unique: true
+  })
+  email: string;
+
+  @Column({
+    type: 'varchar',
+    length: 25,
+    nullable: true
+  })
+  phone: string;
+
+  @Column('bool', {
+    default: true
+  })
+  is_active: boolean;
+
+  @CreateDateColumn({
+    type: 'timestamp',
+    name: 'created_at'
+  })
+  created_at: Date;
+
+  @UpdateDateColumn({
+    type: 'timestamp',
+    name: 'updated_at'
+  })
+  updated_at: Date;
+
+  @DeleteDateColumn({
+    name: 'deleted_at',
+    nullable: true
+  })
+  deleted_at ? : Date | null;
+
+  @OneToMany(() => Address, (address) => address.client, {
+    cascade: true,
+    eager: true
+  })
+  addresses: Address[];
+
+  @BeforeInsert()
+  generateUuid() {
+    this.uuid = uuidv4();
+  }
+
+  @BeforeInsert()
+  checkFieldsBeforeInsert() {
+    this.email = this.email.toLowerCase().trim();
+    this.code = this.code.toUpperCase().trim();
+  }
+
+}


### PR DESCRIPTION
This commit introduces a comprehensive CRUD system for managing clients and their associated addresses.

Key features include:
- **Clients Module**: Full CRUD operations for clients, including creation, listing with filters (by status and creation date range), retrieval, update, and soft delete.
- **Addresses Module**: Granular endpoints for creating, updating, and deleting addresses associated with a client.
- **Primary Address Logic**: Ensures that each client can only have one primary address, with automatic handling when a new primary address is designated.
- **Cascading Soft Deletes**: Deleting a client now correctly soft-deletes all of their associated addresses.
- **UUIDs**: All public-facing endpoints use UUIDs for identification, maintaining consistency with other modern modules in the application.

The implementation follows the existing project structure and conventions established in the `Users` module.